### PR TITLE
Consume and send all reports from a multi-producer single-consumer queue

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/metricq_sink_nsca/check.py
+++ b/metricq_sink_nsca/check.py
@@ -116,7 +116,9 @@ class Check:
         if timeout is not None:
             self._timeout_checks = {
                 metric: TimeoutCheck(
-                    self._timeout, self._get_on_timeout_callback(metric)
+                    self._timeout,
+                    self._get_on_timeout_callback(metric),
+                    name=metric,
                 )
                 for metric in self._metrics
             }

--- a/metricq_sink_nsca/report_queue.py
+++ b/metricq_sink_nsca/report_queue.py
@@ -1,0 +1,65 @@
+# metricq-sink-nsca
+# Copyright (C) 2019 ZIH, Technische Universitaet Dresden, Federal Republic of Germany
+#
+# All rights reserved.
+#
+# This file is part of metricq.
+#
+# metricq is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# metricq is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with metricq.  If not, see <http://www.gnu.org/licenses/>.
+
+from asyncio import FIRST_COMPLETED, Queue, Task, create_task, sleep, wait
+from dataclasses import dataclass
+from typing import AsyncIterator, Optional
+
+from metricq.types import Timedelta
+
+from .state import State
+
+
+@dataclass
+class Report:
+    service: str
+    state: State
+    message: str
+
+
+class ReportQueue:
+    def __init__(self):
+        self._queue: Queue[Report] = Queue()
+
+    def put(self, report: Report) -> None:
+        self._queue.put_nowait(report)
+
+    async def batch(self, timeout: Timedelta) -> AsyncIterator[Report]:
+        timeout_task = create_task(sleep(timeout.s))
+
+        report_task: Optional[Task] = None
+        while True:
+            if report_task is None:
+                report_task = create_task(self._queue.get())
+
+            done, pending = await wait(
+                (report_task, timeout_task),
+                timeout=None,
+                return_when=FIRST_COMPLETED,
+            )
+
+            if report_task in done:
+                yield report_task.result()
+                report_task = None
+
+            if timeout_task in done:
+                if report_task is not None:
+                    report_task.cancel()
+                return

--- a/metricq_sink_nsca/reporter.py
+++ b/metricq_sink_nsca/reporter.py
@@ -85,7 +85,7 @@ class ReporterSink(metricq.DurableSink):
         check: Check
         for name, check in self._checks.items():
             logger.info(f'Cancelling check "{name}"')
-            check.cancel_timeout_checks()
+            check.cancel()
 
         self._checks = dict()
 
@@ -182,7 +182,7 @@ class ReporterSink(metricq.DurableSink):
             check: Check = self._checks.pop(name)
             if check is not None:
                 logger.debug('Removing check "{}"', name)
-                check.cancel_timeout_checks()
+                check.cancel()
 
     def _init_checks(self, check_config) -> None:
         self._checks = dict()

--- a/metricq_sink_nsca/state_cache.py
+++ b/metricq_sink_nsca/state_cache.py
@@ -413,7 +413,11 @@ class StateCache:
                 f"{type(self).__name__} not set up to track state of metric {metric}"
             )
 
-        metric_history.insert(time=timestamp, state=state)
+        try:
+            metric_history.insert(time=timestamp, state=state)
+        except ValueError:
+            raise ValueError(f"Failed to update state history of {metric!r}")
+
         postprocessed_state = self._transition_postprocessor.process(
             metric, state, timestamp, metric_history
         )

--- a/metricq_sink_nsca/state_cache.py
+++ b/metricq_sink_nsca/state_cache.py
@@ -268,6 +268,7 @@ class TransitionPostprocessor(ABC):
     @abstractmethod
     def process(
         self,
+        metric: str,
         current_state: State,
         timestamp: Timestamp,
         history: StateTransitionHistory,
@@ -281,6 +282,7 @@ class TransitionDebounce(TransitionPostprocessor):
 
     def process(
         self,
+        metric: str,
         current_state: State,
         timestamp: Timestamp,
         history: StateTransitionHistory,
@@ -311,6 +313,7 @@ class IgnoreShortTransitions(TransitionPostprocessor):
 
     def process(
         self,
+        metric: str,
         current_state: State,
         _timestamp: Timestamp,
         history: StateTransitionHistory,
@@ -346,6 +349,7 @@ class SoftFail(TransitionPostprocessor):
 
     def process(
         self,
+        metric: str,
         current_state: State,
         _timestamp: Timestamp,
         history: StateTransitionHistory,
@@ -363,7 +367,7 @@ class SoftFail(TransitionPostprocessor):
             if history_len <= self._max_fail_count:
                 logger.warning(
                     f"SoftFail is inconclusive: "
-                    f"history contains only {history_len} transitions, "
+                    f"history of {metric} contains only {history_len} transitions, "
                     f"need at least {self._max_fail_count + 1}!"
                 )
 
@@ -411,10 +415,10 @@ class StateCache:
 
         metric_history.insert(time=timestamp, state=state)
         postprocessed_state = self._transition_postprocessor.process(
-            state, timestamp, metric_history
+            metric, state, timestamp, metric_history
         )
         if postprocessed_state != state:
-            logger.debug(
+            logger.info(
                 f"{type(self._transition_postprocessor).__name__}: "
                 f"adjusted transition for {metric!r}: "
                 f"{state} -> {postprocessed_state}"

--- a/metricq_sink_nsca/subtask.py
+++ b/metricq_sink_nsca/subtask.py
@@ -24,22 +24,23 @@ class Subtask(Generic[Class]):
 
     def start(self):
         if self._task is None:
-            logger.debug("Starting subtask {}", self._name)
+            logger.debug("Starting subtask {!r}", self)
             task = self._task_factory()
             try:
                 self._task = create_task(task, name=self._name)
             except TypeError:
                 self._task = create_task(task)
         else:
-            logger.warning(
-                'Subtask "{}" (id: {:x}) already started!', self._name, id(self)
-            )
+            logger.warning("Subtask {!r} already started!", self)
 
     def cancel(self):
         if self._task is not None:
-            logger.debug("Cancelling subtask {}", self._name)
+            logger.debug("Cancelling subtask {!r}", self)
             self._task.cancel()
             self._task = None
+
+    def __repr__(self):
+        return f"<Subtask: name={self._name!r} at {id(self):#x}>"
 
 
 class SubtaskProxy(Generic[Class]):

--- a/metricq_sink_nsca/subtask.py
+++ b/metricq_sink_nsca/subtask.py
@@ -1,0 +1,93 @@
+from asyncio import Task, create_task
+from functools import partial
+from typing import Awaitable, Callable, Generic, Optional, TypeVar
+
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+Class = TypeVar("Class")
+
+_NOT_FOUND = object()
+
+__all__ = [
+    "subtask",
+    "Subtask",
+]
+
+
+class Subtask(Generic[Class]):
+    def __init__(self, task_factory: Callable[[], Awaitable[None]], name: str):
+        self._task_factory = task_factory
+        self._task: Optional[Task] = None
+        self._name: str = name
+
+    def start(self):
+        if self._task is None:
+            logger.debug("Starting subtask {}", self._name)
+            task = self._task_factory()
+            try:
+                self._task = create_task(task, name=self._name)
+            except TypeError:
+                self._task = create_task(task)
+        else:
+            logger.warning(
+                'Subtask "{}" (id: {:x}) already started!', self._name, id(self)
+            )
+
+    def cancel(self):
+        if self._task is not None:
+            logger.debug("Cancelling subtask {}", self._name)
+            self._task.cancel()
+            self._task = None
+
+
+class SubtaskProxy(Generic[Class]):
+    def __init__(self, method: Callable[[Class], Awaitable[None]]):
+        self._task_method: Callable[[Class], Awaitable[None]] = method
+        self.attrname: Optional[str] = None
+
+        self.__doc__ = method.__doc__
+
+    def __set_name__(self, owner: Class, name: str):
+        if self.attrname is None:
+            self.attrname = name
+        elif self.attrname != name:
+            raise TypeError(
+                "Cannot assign the same subtask to two different names "
+                f"({self.attrname!r} and {name!r})."
+            )
+
+    def __get__(self, instance: Optional[Class], _objtype=None):
+        if instance is None:
+            return self
+
+        cls_name = type(instance).__name__
+
+        try:
+            task = instance.__dict__.get(self.attrname, _NOT_FOUND)
+        except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
+            msg = (
+                f"No '__dict__' attribute on {cls_name!r} "
+                f"instance to save {self.attrname!r} subtask."
+            )
+            raise TypeError(msg) from None
+
+        if task is _NOT_FOUND:
+            task = Subtask(
+                task_factory=partial(self._task_method, instance),
+                name=f"{cls_name}.{self.attrname}",
+            )
+            try:
+                instance.__dict__[self.attrname] = task
+            except TypeError:
+                msg = (
+                    f"The __dict__ attribute of {cls_name!r} "
+                    "does not support item assignment"
+                )
+                raise RuntimeError(msg) from None
+        return task
+
+
+def subtask(f: Callable[[Class], Awaitable[None]]):
+    return SubtaskProxy(f)

--- a/metricq_sink_nsca/timeout_check.py
+++ b/metricq_sink_nsca/timeout_check.py
@@ -45,11 +45,18 @@ class TimeoutCheck:
         self._task: asyncio.Task = asyncio.create_task(self._run())
         self._throttle = False
 
+    def start(self) -> "TimeoutCheck":
+        if self._task is not None:
+            logger.warning("TimeoutCheck already started")
+        self._task = asyncio.create_task(self._run())
+
+        return self
+
     def cancel(self):
-        logger.debug(
-            f"Cancelling task for TimeoutCheck (cancelled: {self._task.cancelled()})"
-        )
-        self._task.cancel()
+        logger.debug("Cancelling task for TimeoutCheck")
+        if self._task is not None:
+            self._task.cancel()
+        self._task = None
 
     def bump(self, last_timestamp: Timestamp):
         self._last_timestamp = last_timestamp

--- a/metricq_sink_nsca/timeout_check.py
+++ b/metricq_sink_nsca/timeout_check.py
@@ -42,14 +42,14 @@ class TimeoutCheck:
 
         self._last_timestamp: Optional[Timestamp] = None
         self._new_timestamp_event: Event = Event()
-        self._task: asyncio.Task = asyncio.create_task(self._run())
+        self._task: Optional[asyncio.Task] = None
         self._throttle = False
 
     def start(self) -> "TimeoutCheck":
-        if self._task is not None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._run())
+        else:
             logger.warning("TimeoutCheck already started")
-        self._task = asyncio.create_task(self._run())
-
         return self
 
     def cancel(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ lint =
     pre-commit
 test =
     pytest
+    pytest-asyncio
 dev =
     %(test)s
     %(lint)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ long_description = file: README.rst
 [options]
 packages =
     metricq_sink_nsca
-python_requires = >= 3.7
+python_requires = >= 3.8
 include_package_data = True
 install_requires =
     metricq ~=1.0
@@ -83,11 +83,10 @@ ignore =
     W503
 
 [tox:tox]
-envlist = py37, py38, black, isort, check-manifest, flake8
+envlist = py38, black, isort, check-manifest, flake8
 
 [gh-actions]
 python =
-    3.7: py37, flake8
     3.8: py38, black, isort, check-manifest, flake8
 
 [testenv]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ license_file = LICENSE.txt
 long_description = file: README.rst
 
 [options]
-packages = find:
+packages =
+    metricq_sink_nsca
 python_requires = >= 3.7
 include_package_data = True
 install_requires =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from metricq.types import Timedelta, Timestamp
 
@@ -23,3 +25,11 @@ class Ticker:
 @pytest.fixture()
 def ticker():
     return Ticker()
+
+
+async def step():
+    await asyncio.sleep(0.0)
+
+
+async def sleep(timeout: Timedelta):
+    await asyncio.sleep(timeout.s)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,83 @@
+import logging
+
+import pytest
+from metricq import Timedelta, Timestamp
+
+from metricq_sink_nsca.check import Check, TvPair
+from metricq_sink_nsca.report_queue import Report, ReportQueue
+from metricq_sink_nsca.state import State
+
+
+@pytest.fixture
+def check():
+    return Check(
+        name="test",
+        metrics=["foo"],
+        report_queue=ReportQueue(),
+        value_constraints=None,
+        resend_interval=Timedelta.from_s(60),
+    )
+
+
+def test_check_internal_exception_report(check):
+    errmsg = "check_metric_raising"
+
+    def check_metric_raising(*args, **kwargs):
+        raise ValueError(errmsg)
+
+    check.check_metric = check_metric_raising
+
+    check.check("foo", tv_pairs=[TvPair(Timestamp(0), 0.0)])
+
+    report: Report = check._report_queue._queue.get_nowait()
+
+    assert report.service == check._name
+    assert report.state == State.CRITICAL
+    assert errmsg in report.message
+
+
+def test_check_internal_chained_exception_report(check):
+    errmsg_toplevel = "top-level exception"
+    errmsg_cause = "chained exception"
+
+    def check_metric_raising(*args, **kwargs):
+        try:
+            raise RuntimeError(errmsg_cause)
+        except RuntimeError as e:
+            raise RuntimeError(errmsg_toplevel) from e
+
+    check.check_metric = check_metric_raising
+
+    check.check("foo", tv_pairs=[TvPair(Timestamp(0), 0.0)])
+
+    report: Report = check._report_queue._queue.get_nowait()
+
+    assert report.service == check._name
+    assert report.state == State.CRITICAL
+
+    header, *causes = report.message.splitlines()
+
+    assert errmsg_toplevel in header
+
+    assert len(causes) == 1
+    assert "caused by:" in causes[0]
+    assert errmsg_cause in causes[0]
+
+
+def test_check_internal_exception_log_entry(check, caplog):
+    errmsg = "check_metric_raising"
+
+    def check_metric_raising(*args, **kwargs):
+        raise ValueError(errmsg)
+
+    check.check_metric = check_metric_raising
+
+    with caplog.at_level(logging.ERROR):
+        check.check("foo", tv_pairs=[TvPair(Timestamp(0), 0.0)])
+
+        assert errmsg in caplog.text
+
+        assert any(
+            "Unhandled exception" in message
+            for logger, level, message in caplog.record_tuples
+        )

--- a/tests/test_report_queue.py
+++ b/tests/test_report_queue.py
@@ -1,0 +1,65 @@
+from typing import Iterator, List, TypeVar
+
+import pytest
+from metricq.types import Timedelta
+
+from metricq_sink_nsca.report_queue import Report, ReportQueue
+from metricq_sink_nsca.state import State
+
+pytestmark = pytest.mark.asyncio
+
+_T = TypeVar("T")
+
+
+def take(it: Iterator[_T], num: int) -> List[_T]:
+    return [item for item, _ in zip(it, range(num))]
+
+
+@pytest.fixture
+def reports():
+    def gen() -> Iterator[Report]:
+        i = 0
+        while True:
+            yield Report(
+                service=f"service.{i}",
+                state=State.OK,
+                message=f"message.{i}",
+            )
+            i += 1
+
+    return gen()
+
+
+@pytest.fixture
+def tick() -> Timedelta:
+    return Timedelta.from_s(0.1)
+
+
+async def test_batch_from_put_before(reports, tick):
+    reports = take(reports, 5)
+    queue = ReportQueue()
+
+    for r in reports:
+        queue.put(r)
+
+    async for expected in queue.batch(tick):
+        assert expected == reports.pop(0)
+
+
+async def test_empty_batch_from_empty_queue(tick):
+    queue = ReportQueue()
+
+    assert [r async for r in queue.batch(tick)] == []
+
+
+async def test_empty_batch_then_some(reports, tick):
+    queue = ReportQueue()
+
+    assert [r async for r in queue.batch(tick)] == []
+
+    batch = take(reports, 5)
+
+    for r in batch:
+        queue.put(r)
+
+    assert [r async for r in queue.batch(tick)] == batch

--- a/tests/test_soft_fail.py
+++ b/tests/test_soft_fail.py
@@ -64,6 +64,6 @@ def test_soft_fail(empty_transition_history, ticker, max_fail_count, transitions
     expected: State
     for (ts, (state, expected)) in zip(ticker, transitions):
         history.insert(ts, state)
-        processed_state = soft_fail.process(state, ts, history)
+        processed_state = soft_fail.process("metric", state, ts, history)
         logger.info(f"ts={ts}, state={state}, processed_state={processed_state}")
         assert processed_state == expected

--- a/tests/test_subtask.py
+++ b/tests/test_subtask.py
@@ -1,4 +1,3 @@
-from asyncio import sleep
 from contextlib import asynccontextmanager
 from logging import WARNING
 
@@ -6,9 +5,7 @@ import pytest
 
 from metricq_sink_nsca.subtask import Subtask, SubtaskProxy, subtask
 
-
-async def step():
-    await sleep(0.0)
+from .conftest import step
 
 
 @pytest.fixture

--- a/tests/test_subtask.py
+++ b/tests/test_subtask.py
@@ -1,0 +1,132 @@
+from asyncio import sleep
+from contextlib import asynccontextmanager
+from logging import WARNING
+
+import pytest
+
+from metricq_sink_nsca.subtask import Subtask, SubtaskProxy, subtask
+
+
+async def step():
+    await sleep(0.0)
+
+
+@pytest.fixture
+def endless_task():
+    async def endless():
+        while True:
+            await step()
+
+    return Subtask(endless, name="endless")
+
+
+@asynccontextmanager
+async def while_running(task: Subtask):
+    task.start()
+    await step()
+
+    yield task
+
+    task.cancel()
+    await step()
+
+
+@pytest.mark.asyncio
+async def test_subtask_start_stop(endless_task):
+    assert endless_task._task is None
+
+    async with while_running(endless_task) as task:
+        assert not task._task.done()
+        save_task = task._task
+
+    assert endless_task._task is None
+    assert save_task.done()
+
+
+@pytest.mark.asyncio
+async def test_subtask_start_again(endless_task, caplog):
+    async with while_running(endless_task) as task:
+        task.start()
+        await step()
+
+    with caplog.at_level(WARNING, logger="metricq_sink_nsca.subtask"):
+        assert "already started" in caplog.text
+
+
+class SubtaskClass:
+    @subtask
+    async def endless(self):
+        while True:
+            await step()
+
+
+@pytest.mark.asyncio
+async def test_subtask_decorator_set_instance():
+    test = SubtaskClass()
+
+    assert "endless" not in test.__dict__, "Subtask set in instance before first access"
+    task = test.endless
+    assert isinstance(task, Subtask), "SubtaskProxy not dereferenced properly"
+    assert "endless" in test.__dict__, "Subtask not created by proxy"
+    assert (
+        task is test.__dict__["endless"]
+    ), "SubtaskProxy returned wrong Subtask object"
+
+
+@pytest.mark.asyncio
+async def test_subtask_decorator_proxy():
+    proxy = SubtaskClass.endless
+    assert isinstance(proxy, SubtaskProxy)
+    assert proxy.attrname == "endless"
+
+
+@pytest.mark.asyncio
+async def test_subtask_decorator_start_stop():
+    test = SubtaskClass()
+
+    assert test.endless._task is None
+
+    async with while_running(test.endless) as task:
+        assert not task._task.done()
+        save_task = task._task
+
+    assert test.endless._task is None
+    assert save_task.done()
+
+
+def test_subtask_no_dunder_dict():
+    class NoDunderDict:
+        __slots__ = []
+
+        @subtask
+        async def impossible(self):
+            pass
+
+    with pytest.raises(TypeError):
+        NoDunderDict().impossible
+
+
+def test_subtask_read_only_dunder_dict():
+    class RoDunderDict:
+        class FrozenDict(dict):
+            def __setitem__(self, index, value):
+                raise TypeError()
+
+        __dict__ = FrozenDict()
+
+        @subtask
+        async def impossible(self):
+            pass
+
+    with pytest.raises(RuntimeError):
+        RoDunderDict().impossible
+
+
+def test_subtask_dunder_doc():
+    class Doc:
+        @subtask
+        async def foo(self):
+            """foo"""
+            pass
+
+    assert Doc.foo.__doc__ == "foo"

--- a/tests/test_timeout_check.py
+++ b/tests/test_timeout_check.py
@@ -1,0 +1,94 @@
+from contextlib import asynccontextmanager
+
+import pytest
+from metricq.types import Timedelta, Timestamp
+
+from metricq_sink_nsca.timeout_check import TimeoutCallback, TimeoutCheck
+
+from .conftest import sleep, step
+
+pytestmark = pytest.mark.asyncio
+
+
+class Callback(TimeoutCallback):
+    def __init__(self):
+        self.called = False
+        self.timeout = None
+        self.last_timestamp = None
+
+    def __call__(self, *, timeout, last_timestamp):
+        self.called = True
+        self.timeout = timeout
+        self.last_timestamp = last_timestamp
+
+    def __repr__(self):
+        return f"<Callback: called={self.called!r}, timeout={self.timeout!r}, last_timestamp={self.last_timestamp!r}>"
+
+
+@pytest.fixture
+def callback() -> Callback:
+    return Callback()
+
+
+@pytest.fixture
+def timeout() -> Timedelta:
+    return Timedelta.from_ms(100)
+
+
+@asynccontextmanager
+async def run(timeout_check: TimeoutCheck) -> TimeoutCheck:
+    try:
+        timeout_check.start()
+        await step()
+        yield timeout_check
+    finally:
+        timeout_check.cancel()
+        await step()
+
+
+@pytest.fixture(scope="function")
+async def timeout_check(
+    timeout,
+    callback,
+) -> TimeoutCheck:
+    async with run(TimeoutCheck(timeout=timeout, on_timeout=callback)) as timeout_check:
+        yield timeout_check
+
+
+async def test_timeout_check_no_bump(timeout_check):
+    await sleep(timeout_check._timeout + Timedelta.from_ms(10))
+
+    callback = timeout_check._timeout_callback
+    assert callback.called
+    assert callback.last_timestamp is None
+    assert callback.timeout == timeout_check._timeout
+
+
+async def test_timeout_check_bump_once(timeout_check: TimeoutCheck):
+    now = Timestamp.now()
+    timeout_check.bump(now)
+
+    await step()
+
+    assert not timeout_check._timeout_callback.called
+    assert timeout_check._last_timestamp == now
+
+
+async def test_timeout_check_no_callback_after_cancel(timeout):
+    class CallOnce(Callback):
+        def __init__(self):
+            self.called_before = False
+            super().__init__()
+
+        def __call__(self, *, timeout, last_timestamp):
+            assert not self.called_before
+            super().__call__(timeout=timeout, last_timestamp=last_timestamp)
+            self.called_before = True
+
+    timeout_check = TimeoutCheck(timeout=timeout, on_timeout=CallOnce())
+
+    timeout_check.start()
+    await sleep(timeout_check._timeout + Timedelta.from_ms(10))
+
+    timeout_check.cancel()
+    await sleep(timeout_check._timeout + Timedelta.from_ms(10))


### PR DESCRIPTION
This restructures how reports are sent for each check, subsuming #5.

Each `Check` can generate reports that fall into two categories:

1. *synchronous reports*: a set of data points is provided to the `Check`, it can decide immediately whether to produce a report to be sent
2. *asynchronous reports*: the `Check` decides to produce a new report without an outside trigger. For example, once a metric runs into a timeout, or a heartbeat report is in order, the `Check` must be able to trigger reports asynchronously.

With this PR, each `Check` is passed a `ReportQueue`. The sink instantiating a check waits for new `Report`s on this queue, while each check populates it with new reports asynchronously.
This way, there is a single task that is responsible for sending _all_ reports:

https://github.com/metricq/metricq-sink-nsca/blob/a8556e6538d450c94478f5b6c10790bde6ac47db/metricq_sink_nsca/reporter.py#L389-L404

while each check can use a single interface for triggering reports: put them into the provided queue, no matter if they are (a)synchronous.

This simplifies rate limiting and report batching.