### PR TITLE
Optionally ignore invalid (esp. non-monotonic) data points

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* :bug:`16` Optionally ignore invalid (especially non-monotonic) data points:
+
+  Use the new configuration key :literal:`ignore_update_errors` (:ref:`here<ignore_update_errors>`) to optionally suppress
+  :literal:`CRITICAL` reports if a check could not be updated because of invalid metric data
 * :feature:`27` (via :issue:`26`) Optionally use :code:`uvloop`-based event loop.
   To enable, install :code:`uvloop` directly, or the :code:`[uvloop]` extra
   (:code:`pip install 'metricq-sink-nsca[uvloop]'`).

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -84,6 +84,20 @@ Top-level configuration
     Default
         :literal:`"3min"`
 
+:code:`ignore_update_errors` (*boolean*)
+    .. _ignore_update_errors:
+
+    Ignore errors that happen when updating the state of a metric with new values.
+
+    If set to :literal:`true`, any invalid *time-value* pair will be dropped.
+    The metric *won't change state* because of this value, even if it is :ref:`abnormal<abnormal-ranges>`.
+    It *won't be marked as alive* because the timestamp,
+    i.e. its associated check signal a timeout-condition if no valid data point arrives :ref:`soon after<timeout>`.
+    A measurement is invalid e.g. if its timestamp indicates a measurement in the past, relative to any measurement received so far.
+
+    Default
+        :literal:`false`: All invalid metric values trigger a :literal:`CRITICAL` report for the associated check.
+
 Check configuration
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -96,7 +96,7 @@ Top-level configuration
     A measurement is invalid e.g. if its timestamp indicates a measurement in the past, relative to any measurement received so far.
 
     Default
-        :literal:`false`: All invalid metric values trigger a :literal:`CRITICAL` report for the associated check.
+        :literal:`true`: All invalid metric values are ignored and won't trigger a :literal:`CRITICAL` report for the associated check.
 
 Check configuration
 ^^^^^^^^^^^^^^^^^^^

--- a/metricq_sink_nsca/check.py
+++ b/metricq_sink_nsca/check.py
@@ -59,6 +59,7 @@ class Check:
         plugins: Optional[Dict[str, Dict]] = None,
         transition_debounce_window: Optional[Timedelta] = None,
         transition_postprocessing: Optional[Dict] = None,
+        ignore_update_errors: bool = False,
     ):
         """Create value- and timeout-checks for a set of metrics
 
@@ -104,6 +105,7 @@ class Check:
             metrics=self._metrics,
             transition_debounce_window=transition_debounce_window,
             transition_postprocessor=transition_postprocessor,
+            ignore_update_errors=ignore_update_errors,
         )
         self._last_overall_state = State.UNKNOWN
 

--- a/metricq_sink_nsca/check.py
+++ b/metricq_sink_nsca/check.py
@@ -59,7 +59,7 @@ class Check:
         plugins: Optional[Dict[str, Dict]] = None,
         transition_debounce_window: Optional[Timedelta] = None,
         transition_postprocessing: Optional[Dict] = None,
-        ignore_update_errors: bool = False,
+        ignore_update_errors: bool = True,
     ):
         """Create value- and timeout-checks for a set of metrics
 

--- a/metricq_sink_nsca/reporter.py
+++ b/metricq_sink_nsca/reporter.py
@@ -71,6 +71,7 @@ class ReporterSink(metricq.DurableSink):
         self._check_configs: Dict[str] = dict()
         self._has_value_checks: bool = False
         self._global_resend_interval: Optional[Timedelta] = None
+        self._ignore_update_errors: bool = False
         self._report_queue = ReportQueue()
 
         super().__init__(*args, client_version=client_version, **kwargs)
@@ -165,6 +166,7 @@ class ReporterSink(metricq.DurableSink):
             plugins=plugins,
             transition_debounce_window=transition_debounce_window,
             transition_postprocessing=transition_postprocessing,
+            ignore_update_errors=self._ignore_update_errors,
         )
 
     def _add_check(self, name: str, config: dict):
@@ -240,6 +242,7 @@ class ReporterSink(metricq.DurableSink):
         nsca: dict,
         reporting_host: str = DEFAULT_HOSTNAME,
         resend_interval: str = "3min",
+        ignore_update_errors: bool = False,
         **_kwargs,
     ) -> None:
         self._reporting_host = reporting_host
@@ -259,6 +262,8 @@ class ReporterSink(metricq.DurableSink):
                 f'Invalid resend interval "{resend_interval}" in configuration: {e}'
             )
             raise
+
+        self._ignore_update_errors = bool(ignore_update_errors)
 
         if not self._checks:
             self._init_checks(checks)

--- a/metricq_sink_nsca/reporter.py
+++ b/metricq_sink_nsca/reporter.py
@@ -242,7 +242,7 @@ class ReporterSink(metricq.DurableSink):
         nsca: dict,
         reporting_host: str = DEFAULT_HOSTNAME,
         resend_interval: str = "3min",
-        ignore_update_errors: bool = False,
+        ignore_update_errors: bool = True,
         **_kwargs,
     ) -> None:
         self._reporting_host = reporting_host

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, Dict
 
 import pytest
 from metricq import Timedelta, Timestamp
@@ -7,16 +8,28 @@ from metricq_sink_nsca.check import Check, TvPair
 from metricq_sink_nsca.report_queue import Report, ReportQueue
 from metricq_sink_nsca.state import State
 
+from tests.conftest import Ticker
+
 
 @pytest.fixture
-def check():
-    return Check(
+def check_default_args() -> Dict[str, Any]:
+    return dict(
         name="test",
         metrics=["foo"],
         report_queue=ReportQueue(),
         value_constraints=None,
         resend_interval=Timedelta.from_s(60),
     )
+
+
+@pytest.fixture
+def check(check_default_args):
+    return Check(**check_default_args)
+
+
+@pytest.fixture
+def check_with_ignore_update_errors(check_default_args: dict) -> Check:
+    return Check(**check_default_args, ignore_update_errors=True)
 
 
 def test_check_internal_exception_report(check):
@@ -81,3 +94,33 @@ def test_check_internal_exception_log_entry(check, caplog):
             "Unhandled exception" in message
             for logger, level, message in caplog.record_tuples
         )
+
+
+def test_check_ignore_update_error(
+    check_with_ignore_update_errors: Check,
+    ticker: Ticker,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Assert that a check that has `ignore_update_errors` set will not generate CRITICAL reports for non-monotonic metrics."""
+    check = check_with_ignore_update_errors
+    report_queue = check._report_queue
+
+    epoch = next(ticker)
+
+    # Make sure the internal state cache has an epoch set
+    check.check("foo", tv_pairs=[TvPair(epoch, 0)])
+    assert report_queue._queue.get_nowait().state == State.OK
+
+    # If ignore_update_errors is set, tv_pairs with duplicate/past timestamps should be ignored.
+    with caplog.at_level(logging.ERROR):
+        duplicate = TvPair(next(ticker), 0)
+        check.check("foo", tv_pairs=[duplicate, duplicate])
+
+        # Make sure a log message at level ERROR is generated
+        assert any(
+            "duplicate" in message and level == logging.ERROR
+            for logger, level, message in caplog.record_tuples
+        )
+
+        # Assert that no report was generated for these values
+        assert check._report_queue._queue.empty()

--- a/tests/test_soft_fail.py
+++ b/tests/test_soft_fail.py
@@ -53,11 +53,17 @@ def empty_transition_history():
         ),
     ],
 )
-def test_soft_fail(empty_transition_history, ticker, max_fail_count, transitions):
+def test_soft_fail(
+    empty_transition_history: StateTransitionHistory,
+    ticker,
+    max_fail_count,
+    transitions,
+):
     soft_fail = SoftFail(max_fail_count)
 
     history = empty_transition_history
     history.insert(next(ticker), State.OK)
+    assert history._epoch is not None
 
     ts: Timestamp
     state: State


### PR DESCRIPTION
**Note**: _This has been put on hold.  There are several issues with reliably detecting false positives<sup>*</sup>.  Due to this it's very hard to run a checker reliably with `ignore_update_errors = False`, making this PR infeasible._

If invalid data points arrives (for example with a non-monotonic timestamp) and the configuration key `ignore_update_errors` is set to `true`, the datapoint is ignored and dropped.

This suppresses the *CRITICAL* report that would be sent otherwise, while still triggering a timeout-report if no valid data point is received soon after (=within the timeout period starting from the last valid data point from).

TODO:

- [ ] reports generated by non-monotonic values should not bypass the usual cooldown mechanism.  If possible, exceptions shouldn't go too far and the `StateCache` should keep track of this condition.