### PR TITLE
Fix leaking `TimoutCheck`s

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+* :bug:`29` Fix a bug where checks would report a timeout error even after they were removed via dynamic reconfiguration.
 * :support:`33` Miscellaneous fixes and improvements
 * :feature:`27` (via :issue:`26`) Optionally use :code:`uvloop`-based event loop.
   To enable, install :code:`uvloop` directly, or the :code:`[uvloop]` extra

--- a/metricq_sink_nsca/check.py
+++ b/metricq_sink_nsca/check.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with metricq.  If not, see <http://www.gnu.org/licenses/>.
 
-from asyncio import CancelledError, sleep
+from asyncio import CancelledError, gather, sleep
 from typing import Dict, Iterable, NamedTuple, Optional, Set
 
 from metricq.types import Timedelta, Timestamp
@@ -319,6 +319,13 @@ class Check:
                 check.cancel()
 
         self.heartbeat.cancel()
+
+    async def stop(self):
+        self.cancel()
+        await gather(
+            self.heartbeat.stop(),
+            *(check.stop() for check in self._timeout_checks.values()),
+        )
 
     def metrics(self) -> Iterable[str]:
         return self._metrics

--- a/metricq_sink_nsca/subtask.py
+++ b/metricq_sink_nsca/subtask.py
@@ -1,4 +1,5 @@
-from asyncio import Task, create_task
+from asyncio import CancelledError, Task, create_task
+from contextlib import suppress
 from functools import partial
 from typing import (
     Awaitable,
@@ -56,7 +57,8 @@ class Subtask(Generic[Class]):
         self.cancel()
         if self._task is not None:
             logger.debug("Waiting for subtask {!r} to finish...", self)
-            await self._task
+            with suppress(CancelledError):
+                await self._task
 
     def __repr__(self):
         return f"<Subtask: name={self._name!r} at {id(self):#x}>"

--- a/metricq_sink_nsca/subtask.py
+++ b/metricq_sink_nsca/subtask.py
@@ -49,13 +49,14 @@ class Subtask(Generic[Class]):
         if self._task is not None:
             logger.debug("Cancelling subtask {!r}", self)
             self._task.cancel()
-            self._task = None
+        else:
+            logger.debug("Cancelling subtask {!r} that never ran!", self)
 
     async def stop(self):
+        self.cancel()
         if self._task is not None:
-            self._task.cancel()
+            logger.debug("Waiting for subtask {!r} to finish...", self)
             await self._task
-            self._task = None
 
     def __repr__(self):
         return f"<Subtask: name={self._name!r} at {id(self):#x}>"

--- a/metricq_sink_nsca/timeout_check.py
+++ b/metricq_sink_nsca/timeout_check.py
@@ -103,6 +103,7 @@ class TimeoutCheck:
                         await self._run_timeout_callback_after(wait_duration)
         except CancelledError:
             logger.info("{!r}: stopped", self)
+            raise
         except Exception as e:  # pylint: disable=broad-except
             logger.exception(
                 "{!r}: unexpected error inside TimeoutCheck callback: {}", self, e

--- a/tests/test_subtask.py
+++ b/tests/test_subtask.py
@@ -34,10 +34,8 @@ async def test_subtask_start_stop(endless_task):
 
     async with while_running(endless_task) as task:
         assert not task._task.done()
-        save_task = task._task
 
-    assert endless_task._task is None
-    assert save_task.done()
+    assert endless_task._task.done()
 
 
 @pytest.mark.asyncio
@@ -85,10 +83,9 @@ async def test_subtask_decorator_start_stop():
 
     async with while_running(test.endless) as task:
         assert not task._task.done()
-        save_task = task._task
 
-    assert test.endless._task is None
-    assert save_task.done()
+    assert test.endless._task is not None
+    assert test.endless._task.done()
 
 
 def test_subtask_no_dunder_dict():


### PR DESCRIPTION
This fixes a bug where active `TimeoutCheck`s would linger around even after they where disposed of in a reconfiguration.