### PR TITLE
Use correct configuration when updating check

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* :bug:`35` Fix a bug where reconfiguration of a check configuration at runtime would result in an error or misconfiguration.
+
 * :release:`1.7.0 <2021-06-08>`
 * :bug:`29 major` Fix a bug where checks would report a timeout error even after they were removed via dynamic reconfiguration.
 * :support:`33` Miscellaneous fixes and improvements


### PR DESCRIPTION
When updating a check with a new configuration, `remove_and_add()` passed the wrong `dict` to `ReporterSink._add_check()`:

```diff
 updated_check_config = ...

 async def remove_and_add(name: str, updated_config: dict):
     logger.info('Removing out-of-date check "{}"...', name)
     await self._remove_check(name, timeout=1.0)
     logger.info('Adding check "{}" with updated configuration', name)
-    self._add_check(name, updated_check_config)
+    self._add_check(name, updated_config)
```

Add a new `CheckConfig` type annotation that hopefully catches such typos in the future.

This might explain the mysterious error we got when updating some check configurations:


```log
[2021-06-14 10:27:57,629] [INFO ] [metricq_sink_nsca.reporter] Adding check "<XXX>" with updated configuration
[2021-06-14 10:27:57,629] [INFO ] [metricq_sink_nsca.reporter] Adding check "<XXX>"
[2021-06-14 10:27:57,690] [ERROR] [metricq.agent       ] error handling RPC config (<class 'ValueError'>): Traceback (most recent call last):
  File "<env>/lib/python3.9/site-packages/metricq/agent.py", line 544, in _on_management_message
    response = await self.rpc_dispatch(**arguments)
  File "<env>/lib/python3.9/site-packages/metricq/rpc.py", line 95, in rpc_dispatch
    rv = await task
  File "<env>/lib/python3.9/site-packages/metricq_sink_nsca/reporter.py", line 288, in _configure
    await self._update_checks(checks)
  File "<env>/lib/python3.9/site-packages/metricq_sink_nsca/reporter.py", line 236, in _update_checks
    await asyncio.gather(
  File "<env>/lib/python3.9/site-packages/metricq_sink_nsca/reporter.py", line 234, in remove_and_add
    self._add_check(name, updated_check_config)
  File "<env>/lib/python3.9/site-packages/metricq_sink_nsca/reporter.py", line 182, in _add_check
    check = self._parse_check_from_config(name, config)
  File "<env>/lib/python3.9/site-packages/metricq_sink_nsca/reporter.py", line 109, in _parse_check_from_config
    raise ValueError("Check does not contain any metrics")
ValueError: Check does not contain any metrics
```