### PR TITLE
Log `INFO` message when sending reports

### DIFF
--- a/metricq_sink_nsca/reporter.py
+++ b/metricq_sink_nsca/reporter.py
@@ -392,7 +392,7 @@ class ReporterSink(metricq.DurableSink):
         if not reports:
             return
 
-        logger.debug(f"Sending {len(reports)} report(s)")
+        logger.info("Sending {} NSCA report(s)", len(reports))
 
         if self._dry_run:
             return


### PR DESCRIPTION
This should make debugging issues like #38 a bit easier.